### PR TITLE
tryCatch new return union type

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,15 +87,15 @@ The http module exports a handy utility to provide a common interface for try/ca
 It abstracts the try catch logic and returns a baked tuple of `[string | undefined, responseData | undefined]`.
 
 ```ts
-import http, { tryCatch } from '@chrillaz/http';
+import http, { tryCatch, isHttpError } from '@chrillaz/http';
 
 type TypeForResponseDataProperty = {};
 
-const [errorMessage, responseData] = tryCatch<TypeForResponseDataProperty>(
+const response = tryCatch<TypeForResponseDataProperty>(
 	http.get('https://domain.com/path')
 );
 
-if (error) {
+if (isError(response)) {
     // do this
 } else {
     // do that

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@chrillaz/http",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"description": "fetch wrapper",
 	"author": "Christoffer Öhman",
 	"license": "ISC",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export { create, http as default } from './http';
-export { tryCatch } from './trycatch';
+export { tryCatch, isHttpError } from './trycatch';
 export * from './types';

--- a/src/trycatch.test.ts
+++ b/src/trycatch.test.ts
@@ -1,4 +1,4 @@
-import { isHttpError, tryCatch } from './trycatch';
+import { isHttpError, tryCatch, unknwonError } from './trycatch';
 import http from './index';
 jest.mock('http');
 
@@ -13,7 +13,6 @@ describe('trycatch', () => {
 	};
 
 	const errorResponse = new Error('Something went wrong');
-	const unknownResponse = 'Unknown Error.';
 
 	http.get = jest
 		.fn()
@@ -40,7 +39,7 @@ describe('trycatch', () => {
 		const response = await tryCatch(http.get('/'));
 
         if (isHttpError(response)) {
-            expect(response.message).toEqual(unknownResponse);
+            expect(response.message).toEqual(unknwonError);
         }
 	});
 });

--- a/src/trycatch.test.ts
+++ b/src/trycatch.test.ts
@@ -13,7 +13,7 @@ describe('trycatch', () => {
 	};
 
 	const errorResponse = new Error('Something went wrong');
-	const unknownResponse = 'Unknown error';
+	const unknownResponse = 'Unknown Error.';
 
 	http.get = jest
 		.fn()

--- a/src/trycatch.test.ts
+++ b/src/trycatch.test.ts
@@ -1,4 +1,4 @@
-import { tryCatch } from './trycatch';
+import { isHttpError, tryCatch } from './trycatch';
 import http from './index';
 jest.mock('http');
 
@@ -22,32 +22,25 @@ describe('trycatch', () => {
 		.mockImplementationOnce(() => Promise.reject());
 
 	test('Successfull promise', async () => {
-		const [
-			error,
-			data,
-		] = await tryCatch(http.get('/'));
+		const response = await tryCatch(http.get('/'));
 
-		expect(data).toEqual(successResponse.data);
-		expect(error).not.toBeDefined();
+		expect(response).toEqual(successResponse.data);
+		expect(isHttpError(response)).toBeFalsy();
 	});
 
 	test('Failing promise with error', async () => {
-		const [
-			error,
-			data,
-		] = await tryCatch(http.get('/'));
+		const response = await tryCatch(http.get('/'));
 
-		expect(error).toEqual(errorResponse.message);
-		expect(data).not.toBeDefined();
+        if (isHttpError(response)) {
+            expect(response.message).toEqual(errorResponse.message);
+        }
 	});
 
 	test('Failing promise with unknown error', async () => {
-		const [
-			error,
-			data,
-		] = await tryCatch(http.get('/'));
+		const response = await tryCatch(http.get('/'));
 
-		expect(error).toEqual(unknownResponse);
-		expect(data).not.toBeDefined();
+        if (isHttpError(response)) {
+            expect(response.message).toEqual(unknownResponse);
+        }
 	});
 });

--- a/src/trycatch.ts
+++ b/src/trycatch.ts
@@ -1,5 +1,7 @@
 import { HttpResponse } from "./types";
 
+export const unknwonError = 'Unknown Error.';
+
 type ErrorWithMessage = {
 	message: string;
 };
@@ -32,7 +34,7 @@ async function tryCatch<Data = unknown>(
 
 		return data;
 	} catch (error) {
-        let message = 'Unknwon Error.';
+        let message = unknwonError;
 		if (errorWithMessage(error)) {
 			message = error.message;
 		}


### PR DESCRIPTION
Returning response from tryCatch uninon type
`HttpError | ResponseData`

exposed isHttpError helper for type narrowing.